### PR TITLE
CMake: add `cmake_minimum_required()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.15)
 project (GeographicLib)
 
 # Version information


### PR DESCRIPTION
`cmake_minimum_required()` is needed, otherwise many things can't properly work (external injection of toolchain, policies etc). 3.15 is a recommended minimum for good default policies in modern CMake, but it can be decreased if you want.