### PR TITLE
cmake: fix postfix debug link problem with pkgconfig

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -92,6 +92,7 @@ endif ()
 # Support for pkgconfig/geographiclib.pc
 set (prefix ${CMAKE_INSTALL_PREFIX})
 set (exec_prefix "\${prefix}")
+set (lib_postfix ${CMAKE_DEBUG_POSTFIX})
 set (libdir "\${exec_prefix}/${LIBDIR}")
 set (includedir "\${prefix}/${INCDIR}")
 set (bindir "\${exec_prefix}/${BINDIR}")

--- a/cmake/project.pc.in
+++ b/cmake/project.pc.in
@@ -10,5 +10,5 @@ Version: @PACKAGE_VERSION@
 URL: https://geographiclib.sourceforge.io
 
 Requires:
-Libs: -L${libdir} -l@PACKAGE_NAME@
+Libs: -L${libdir} -l@PACKAGE_NAME@@lib_postfix@
 Cflags: -I${includedir}


### PR DESCRIPTION
When using pkgconfig, the postfix is not used to find the debug library