### PR TITLE
Also replace @lib_postfix@ in pkg-config template when using Autotools.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ experimental/Makefile
 PKG_PROG_PKG_CONFIG
 PKG_INSTALLDIR
 
+AC_SUBST(lib_postfix,"")
 AC_CONFIG_FILES([cmake/geographiclib.pc:cmake/project.pc.in])
 
 AC_OUTPUT


### PR DESCRIPTION
The lintian QA tool reported pkg-config-bad-directive issue for the Debian package build.

The autotools build also needs to replace `@lib_postfix@` in the pkg-config template.