### PR TITLE
Remove unnecessary toolset restriction

### DIFF
--- a/cmake/project-config-version.cmake.in
+++ b/cmake/project-config-version.cmake.in
@@ -28,14 +28,6 @@ elseif (NOT (APPLE OR (NOT DEFINED CMAKE_SIZEOF_VOID_P) OR
   # since a multi-architecture library is built for that platform).
   set (REASON "sizeof(*void) =  @CMAKE_SIZEOF_VOID_P@")
   set (PACKAGE_VERSION_UNSUITABLE TRUE)
-elseif (MSVC AND NOT (
-    # toolset version must be at least as great as @PROJECT_NAME@'s.
-    MSVC_TOOLSET_VERSION GREATER_EQUAL @MSVC_TOOLSET_VERSION@
-    # and major versions must match
-    AND MSVC_TOOLSET_MAJOR EQUAL @MSVC_TOOLSET_MAJOR@ ))
-  # Reject if there's a mismatch in MSVC compiler versions.
-  set (REASON "MSVC_TOOLSET_VERSION = @MSVC_TOOLSET_VERSION@")
-  set (PACKAGE_VERSION_UNSUITABLE TRUE)
 elseif (GEOGRAPHICLIB_PRECISION MATCHES "^[1-5]\$" AND NOT (
       GEOGRAPHICLIB_PRECISION EQUAL @GEOGRAPHICLIB_PRECISION@ ))
   # Reject if the user asks for an incompatible precsision.


### PR DESCRIPTION
I encountered this error with vcpkg.

```text
CMake Error at C:/src/vcpkg/scripts/buildsystems/vcpkg.cmake:855 (_find_package):
  Could not find a configuration file for package "GeographicLib" that is
  compatible with requested version "".

  The following configuration files were considered but not accepted:

    C:/src/vcpkg/installed/x64-windows/share/geographiclib/geographiclib-config.cmake, version: 2.3 (MSVC_TOOLSET_VERSION = 143)
    C:/src/vcpkg/packages/geographiclib_x64-windows/share/geographiclib/geographiclib-config.cmake, version: 2.3 (MSVC_TOOLSET_VERSION = 143)		
```

My environment:
- Windows 11 Pro
- VS 2022 Community
- VS 2019 Professional

CMake succeeds on VS 2022 but fails on VS 2019.
If I manually remove this block, then CMake succeeds on VS 2019, so I think this is not mandatory.

Related links:
- https://github.com/microsoft/vcpkg/issues/24035
- https://github.com/microsoft/vcpkg/pull/32858