### PR TITLE
Add CMake packaging config export test

### DIFF
--- a/tests/cmake_find_pkg/CMakeLists.txt
+++ b/tests/cmake_find_pkg/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required (VERSION 3.5.0)
+project(geographiclib_cmake_find_pkg)
+
+find_package(GeographicLib CONFIG REQUIRED)
+
+add_executable(main_static main.cpp)
+target_link_libraries(main_static PRIVATE GeographicLib::GeographicLib)
+
+add_executable(main_shared main.cpp)
+target_link_libraries(main_shared PRIVATE GeographicLib::GeographicLib_SHARED)

--- a/tests/cmake_find_pkg/README.md
+++ b/tests/cmake_find_pkg/README.md
@@ -1,0 +1,21 @@
+# CMake find_package tests
+
+The purpose of this directory is to test the CONFIG mode CMake export can be found and used successfully. 
+
+
+## Instructions
+
+
+On Linux:
+
+```bash
+cd /path/to/GeoGraphicLib
+cmake -S . -B build
+cmake --build build
+cmake --install build --prefix install
+cd tests/cmake_find_pkg
+cmake -S . -B build -DCMAKE_PREFIX_PATH=../../install
+cmake --build build
+./build/main_static
+./build/main_shared
+```

--- a/tests/cmake_find_pkg/main.cpp
+++ b/tests/cmake_find_pkg/main.cpp
@@ -1,0 +1,20 @@
+// https://geographiclib.sourceforge.io/C++/doc/start.html
+// Small example of using the GeographicLib::Geodesic class
+ 
+#include <iostream>
+#include <GeographicLib/Geodesic.hpp>
+ 
+using namespace std;
+using namespace GeographicLib;
+ 
+int main() {
+  const Geodesic& geod = Geodesic::WGS84();
+  // Distance from JFK to LHR
+  double
+    lat1 = 40.6, lon1 = -73.8, // JFK Airport
+    lat2 = 51.6, lon2 = -0.5;  // LHR Airport
+  double s12;
+  geod.Inverse(lat1, lon1, lat2, lon2, s12);
+  cout << s12 / 1000 << " km\n";
+  return 0;
+}


### PR DESCRIPTION
CMake configuration-based installs are becoming an increasingly popular (and recommended) way to consume packages.

The process in the README should be run at release time to verify CMake export still works. 

Without this check, it can be easy to break the CMake export and not realize it till after release when users or packaging maintainers (debian/ubuntu maintainers) find problems.

Examples of downstream issues: 
https://bugs.launchpad.net/ubuntu/+source/geographiclib/+bug/1805173