### PR TITLE
fix g++ 13.2.0 warnings when using C++ standard >= 20

### DIFF
--- a/include/GeographicLib/GARS.hpp
+++ b/include/GeographicLib/GARS.hpp
@@ -40,21 +40,19 @@ namespace GeographicLib {
     typedef Math::real real;
     static const char* const digits_;
     static const char* const letters_;
-    enum {
-      lonorig_ = -Math::hd,     // Origin for longitude
-      latorig_ = -Math::qd,     // Origin for latitude
-      baselon_ = 10,            // Base for longitude tiles
-      baselat_ = 24,            // Base for latitude tiles
-      lonlen_ = 3,
-      latlen_ = 2,
-      baselen_ = lonlen_ + latlen_,
-      mult1_ = 2,               // base precision = 1/2 degree
-      mult2_ = 2,               // 6th char gives 2x more precision
-      mult3_ = 3,               // 7th char gives 3x more precision
-      m_ = mult1_ * mult2_ * mult3_,
-      maxprec_ = 2,
-      maxlen_ = baselen_ + maxprec_
-    };
+    static constexpr int lonorig_ = -Math::hd; // Origin for longitude
+    static constexpr int latorig_ = -Math::qd; // Origin for latitude
+    static constexpr int baselon_ = 10;        // Base for longitude tiles
+    static constexpr int baselat_ = 24;        // Base for latitude tiles
+    static constexpr int lonlen_ = 3;
+    static constexpr int latlen_ = 2;
+    static constexpr int baselen_ = lonlen_ + latlen_;
+    static constexpr int mult1_ = 2;           // base precision = 1/2 degree
+    static constexpr int mult2_ = 2;           // 6th char gives 2x more precision
+    static constexpr int mult3_ = 3;           // 7th char gives 3x more precision
+    static constexpr int m_ = mult1_ * mult2_ * mult3_;
+    static constexpr int maxprec_ = 2;
+    static constexpr int maxlen_ = baselen_ + maxprec_;
     GARS() = delete;            // Disable constructor
 
   public:

--- a/include/GeographicLib/Geodesic.hpp
+++ b/include/GeographicLib/Geodesic.hpp
@@ -194,18 +194,16 @@ namespace GeographicLib {
     unsigned maxit2_;
     real tiny_, tol0_, tol1_, tol2_, tolb_, xthresh_;
 
-    enum captype {
-      CAP_NONE = 0U,
-      CAP_C1   = 1U<<0,
-      CAP_C1p  = 1U<<1,
-      CAP_C2   = 1U<<2,
-      CAP_C3   = 1U<<3,
-      CAP_C4   = 1U<<4,
-      CAP_ALL  = 0x1FU,
-      CAP_MASK = CAP_ALL,
-      OUT_ALL  = 0x7F80U,
-      OUT_MASK = 0xFF80U,       // Includes LONG_UNROLL
-    };
+    static constexpr unsigned CAP_NONE = 0U;
+    static constexpr unsigned CAP_C1   = 1U<<0;
+    static constexpr unsigned CAP_C1p  = 1U<<1;
+    static constexpr unsigned CAP_C2   = 1U<<2;
+    static constexpr unsigned CAP_C3   = 1U<<3;
+    static constexpr unsigned CAP_C4   = 1U<<4;
+    static constexpr unsigned CAP_ALL  = 0x1FU;
+    static constexpr unsigned CAP_MASK = CAP_ALL;
+    static constexpr unsigned OUT_ALL  = 0x7F80U;
+    static constexpr unsigned OUT_MASK = 0xFF80U;    // Includes LONG_UNROLL
 
     static real SinCosSeries(bool sinp,
                              real sinx, real cosx, const real c[], int n);

--- a/include/GeographicLib/GeodesicExact.hpp
+++ b/include/GeographicLib/GeodesicExact.hpp
@@ -93,18 +93,16 @@ namespace GeographicLib {
     unsigned maxit2_;
     real tiny_, tol0_, tol1_, tol2_, tolb_, xthresh_;
 
-    enum captype {
-      CAP_NONE = 0U,
-      CAP_E    = 1U<<0,
-      // Skip 1U<<1 for compatibility with Geodesic (not required)
-      CAP_D    = 1U<<2,
-      CAP_H    = 1U<<3,
-      CAP_C4   = 1U<<4,
-      CAP_ALL  = 0x1FU,
-      CAP_MASK = CAP_ALL,
-      OUT_ALL  = 0x7F80U,
-      OUT_MASK = 0xFF80U,       // Includes LONG_UNROLL
-    };
+    static constexpr unsigned CAP_NONE = 0U;
+    static constexpr unsigned CAP_E    = 1U<<0;
+    // Skip 1U<<1 for compatibility with Geodesic (not required)
+    static constexpr unsigned CAP_D    = 1U<<2;
+    static constexpr unsigned CAP_H    = 1U<<3;
+    static constexpr unsigned CAP_C4   = 1U<<4;
+    static constexpr unsigned CAP_ALL  = 0x1FU;
+    static constexpr unsigned CAP_MASK = CAP_ALL;
+    static constexpr unsigned OUT_ALL  = 0x7F80U;
+    static constexpr unsigned OUT_MASK = 0xFF80U;       // Includes LONG_UNROLL
 
     static real Astroid(real x, real y);
 

--- a/include/GeographicLib/GeodesicLine.hpp
+++ b/include/GeographicLib/GeodesicLine.hpp
@@ -104,18 +104,17 @@ namespace GeographicLib {
                  real azi1, real salp1, real calp1,
                  unsigned caps, bool arcmode, real s13_a13);
 
-    enum captype {
-      CAP_NONE = Geodesic::CAP_NONE,
-      CAP_C1   = Geodesic::CAP_C1,
-      CAP_C1p  = Geodesic::CAP_C1p,
-      CAP_C2   = Geodesic::CAP_C2,
-      CAP_C3   = Geodesic::CAP_C3,
-      CAP_C4   = Geodesic::CAP_C4,
-      CAP_ALL  = Geodesic::CAP_ALL,
-      CAP_MASK = Geodesic::CAP_MASK,
-      OUT_ALL  = Geodesic::OUT_ALL,
-      OUT_MASK = Geodesic::OUT_MASK,
-    };
+    static constexpr unsigned CAP_NONE = Geodesic::CAP_NONE;
+    static constexpr unsigned CAP_C1   = Geodesic::CAP_C1;
+    static constexpr unsigned CAP_C1p  = Geodesic::CAP_C1p;
+    static constexpr unsigned CAP_C2   = Geodesic::CAP_C2;
+    static constexpr unsigned CAP_C3   = Geodesic::CAP_C3;
+    static constexpr unsigned CAP_C4   = Geodesic::CAP_C4;
+    static constexpr unsigned CAP_ALL  = Geodesic::CAP_ALL;
+    static constexpr unsigned CAP_MASK = Geodesic::CAP_MASK;
+    static constexpr unsigned OUT_ALL  = Geodesic::OUT_ALL;
+    static constexpr unsigned OUT_MASK = Geodesic::OUT_MASK;
+
   public:
 
     /**

--- a/include/GeographicLib/GeodesicLineExact.hpp
+++ b/include/GeographicLib/GeodesicLineExact.hpp
@@ -67,17 +67,16 @@ namespace GeographicLib {
                       real azi1, real salp1, real calp1,
                       unsigned caps, bool arcmode, real s13_a13);
 
-    enum captype {
-      CAP_NONE = GeodesicExact::CAP_NONE,
-      CAP_E    = GeodesicExact::CAP_E,
-      CAP_D    = GeodesicExact::CAP_D,
-      CAP_H    = GeodesicExact::CAP_H,
-      CAP_C4   = GeodesicExact::CAP_C4,
-      CAP_ALL  = GeodesicExact::CAP_ALL,
-      CAP_MASK = GeodesicExact::CAP_MASK,
-      OUT_ALL  = GeodesicExact::OUT_ALL,
-      OUT_MASK = GeodesicExact::OUT_MASK,
-    };
+    static constexpr unsigned CAP_NONE = GeodesicExact::CAP_NONE;
+    static constexpr unsigned CAP_E    = GeodesicExact::CAP_E;
+    static constexpr unsigned CAP_D    = GeodesicExact::CAP_D;
+    static constexpr unsigned CAP_H    = GeodesicExact::CAP_H;
+    static constexpr unsigned CAP_C4   = GeodesicExact::CAP_C4;
+    static constexpr unsigned CAP_ALL  = GeodesicExact::CAP_ALL;
+    static constexpr unsigned CAP_MASK = GeodesicExact::CAP_MASK;
+    static constexpr unsigned OUT_ALL  = GeodesicExact::OUT_ALL;
+    static constexpr unsigned OUT_MASK = GeodesicExact::OUT_MASK;
+
   public:
 
     /**

--- a/include/GeographicLib/Georef.hpp
+++ b/include/GeographicLib/Georef.hpp
@@ -42,15 +42,13 @@ namespace GeographicLib {
     static const char* const lontile_;
     static const char* const lattile_;
     static const char* const degrees_;
-    enum {
-      tile_ = 15,               // The size of tile in degrees
-      lonorig_ = -Math::hd,     // Origin for longitude
-      latorig_ = -Math::qd,     // Origin for latitude
-      base_ = 10,               // Base for minutes
-      baselen_ = 4,
-      maxprec_ = 11,            // approximately equivalent to MGRS class
-      maxlen_ = baselen_ + 2 * maxprec_
-    };
+    static constexpr int tile_ = 15;           // The size of tile in degrees
+    static constexpr int lonorig_ = -Math::hd; // Origin for longitude
+    static constexpr int latorig_ = -Math::qd; // Origin for latitude
+    static constexpr int base_ = 10;           // Base for minutes
+    static constexpr int baselen_ = 4;
+    static constexpr int maxprec_ = 11;        // approximately equivalent to MGRS class
+    static constexpr int maxlen_ = baselen_ + 2 * maxprec_;
     Georef() = delete;          // Disable constructor
 
   public:

--- a/include/GeographicLib/MGRS.hpp
+++ b/include/GeographicLib/MGRS.hpp
@@ -88,19 +88,17 @@ namespace GeographicLib {
     static const int maxeasting_[4];
     static const int minnorthing_[4];
     static const int maxnorthing_[4];
-    enum {
-      base_ = 10,
-      // Top-level tiles are 10^5 m = 100 km on a side
-      tilelevel_ = 5,
-      // Period of UTM row letters
-      utmrowperiod_ = 20,
-      // Row letters are shifted by 5 for even zones
-      utmevenrowshift_ = 5,
-      // Maximum precision is um
-      maxprec_ = 5 + 6,
-      // For generating digits at maxprec
-      mult_ = 1000000
-    };
+    static constexpr int base_ = 10;
+    // Top-level tiles are 10^5 m = 100 km on a side
+    static constexpr int tilelevel_ = 5;
+    // Period of UTM row letters
+    static constexpr int utmrowperiod_ = 20;
+    // Row letters are shifted by 5 for even zones
+    static constexpr int utmevenrowshift_ = 5;
+    // Maximum precision is um
+    static constexpr int maxprec_ = 5 + 6;
+    // For generating digits at maxprec
+    static constexpr int mult_ = 1000000;
     static void CheckCoords(bool utmp, bool& northp, real& x, real& y);
     static int UTMRow(int iband, int icol, int irow);
 
@@ -137,24 +135,22 @@ namespace GeographicLib {
       // X 9  80:94  15
       return y >= 0 ? b : -(b + 1);
     }
-    // UTMUPS accesses these enums
-    enum {
-      tile_ = 100000,            // Size MGRS blocks
-      minutmcol_ = 1,
-      maxutmcol_ = 9,
-      minutmSrow_ = 10,
-      maxutmSrow_ = 100,         // Also used for UTM S false northing
-      minutmNrow_ = 0,           // Also used for UTM N false northing
-      maxutmNrow_ = 95,
-      minupsSind_ = 8,           // These 4 ind's apply to easting and northing
-      maxupsSind_ = 32,
-      minupsNind_ = 13,
-      maxupsNind_ = 27,
-      upseasting_ = 20,          // Also used for UPS false northing
-      utmeasting_ = 5,           // UTM false easting
-      // Difference between S hemisphere northing and N hemisphere northing
-      utmNshift_ = (maxutmSrow_ - minutmNrow_) * tile_
-    };
+    // UTMUPS accesses these constants
+    static constexpr int tile_ = 100000;    // Size MGRS blocks
+    static constexpr int minutmcol_ = 1;
+    static constexpr int maxutmcol_ = 9;
+    static constexpr int minutmSrow_ = 10;
+    static constexpr int maxutmSrow_ = 100; // Also used for UTM S false northing
+    static constexpr int minutmNrow_ = 0;   // Also used for UTM N false northing
+    static constexpr int maxutmNrow_ = 95;
+    static constexpr int minupsSind_ = 8;   // These 4 ind's apply to easting and northing
+    static constexpr int maxupsSind_ = 32;
+    static constexpr int minupsNind_ = 13;
+    static constexpr int maxupsNind_ = 27;
+    static constexpr int upseasting_ = 20;  // Also used for UPS false northing
+    static constexpr int utmeasting_ = 5;   // UTM false easting
+    // Difference between S hemisphere northing and N hemisphere northing
+    static constexpr int utmNshift_ = (maxutmSrow_ - minutmNrow_) * tile_;
     MGRS() = delete;            // Disable constructor
 
   public:

--- a/include/GeographicLib/Math.hpp
+++ b/include/GeographicLib/Math.hpp
@@ -134,14 +134,12 @@ namespace GeographicLib {
      * break most of the tests.  Also the normal definition of degree is baked
      * into some classes, e.g., UTMUPS, MGRS, Georef, Geohash, etc.
      **********************************************************************/
-    enum dms {
-      qd = 90,                  ///< degrees per quarter turn
-      dm = 60,                  ///< minutes per degree
-      ms = 60,                  ///< seconds per minute
-      hd = 2 * qd,              ///< degrees per half turn
-      td = 2 * hd,              ///< degrees per turn
-      ds = dm * ms              ///< seconds per degree
-    };
+    static constexpr int qd = 90;            ///< degrees per quarter turn
+    static constexpr int dm = 60;            ///< minutes per degree
+    static constexpr int ms = 60;            ///< seconds per minute
+    static constexpr int hd = 2 * qd;        ///< degrees per half turn
+    static constexpr int td = 2 * hd;        ///< degrees per turn
+    static constexpr int ds = dm * ms;       ///< seconds per degree
 
     /**
      * @return the number of bits of precision in a real number.

--- a/include/GeographicLib/OSGB.hpp
+++ b/include/GeographicLib/OSGB.hpp
@@ -47,20 +47,18 @@ namespace GeographicLib {
     static const char* const letters_;
     static const char* const digits_;
     static const TransverseMercator& OSGBTM();
-    enum {
-      base_ = 10,
-      tile_ = 100000,
-      tilelevel_ = 5,
-      tilegrid_ = 5,
-      tileoffx_ = 2 * tilegrid_,
-      tileoffy_ = 1 * tilegrid_,
-      minx_ = - tileoffx_ * tile_,
-      miny_ = - tileoffy_ * tile_,
-      maxx_ = (tilegrid_*tilegrid_ - tileoffx_) * tile_,
-      maxy_ = (tilegrid_*tilegrid_ - tileoffy_) * tile_,
-      // Maximum precision is um
-      maxprec_ = 5 + 6
-    };
+    static constexpr int base_ = 10;
+    static constexpr int tile_ = 100000;
+    static constexpr int tilelevel_ = 5;
+    static constexpr int tilegrid_ = 5;
+    static constexpr int tileoffx_ = 2 * tilegrid_;
+    static constexpr int tileoffy_ = 1 * tilegrid_;
+    static constexpr int minx_ = - tileoffx_ * tile_;
+    static constexpr int miny_ = - tileoffy_ * tile_;
+    static constexpr int maxx_ = (tilegrid_*tilegrid_ - tileoffx_) * tile_;
+    static constexpr int maxy_ = (tilegrid_*tilegrid_ - tileoffy_) * tile_;
+    // Maximum precision is um
+    static constexpr int maxprec_ = 5 + 6;
     static real computenorthoffset();
     static void CheckCoords(real x, real y);
     OSGB() = delete;            // Disable constructor


### PR DESCRIPTION
This set of changes resolves compiler warnings from GCC 13.2.0 when building using the C++ 20 or 23 standard.

See [c++20_build_log.txt](https://github.com/geographiclib/geographiclib/files/15328079/c%2B%2B20_build_log.txt) for full build output showing all the warnings.

To build in C++20 mode, I just changed the 11 on line 267 of the root CMakeLists.txt to 20 in my local tree.  I verified it builds without warnings and all unit tests pass using C++ standards 11, 14, 17, 20, and 23 with this set of changes.  11, 14, and 17 did not produce warnings prior to this set of changes.