### PR TITLE
Added move constructor/assignment support for MagneticModel/GravityModel

### DIFF
--- a/include/GeographicLib/GravityModel.hpp
+++ b/include/GeographicLib/GravityModel.hpp
@@ -159,6 +159,17 @@ namespace GeographicLib {
        **********************************************************************/
       ALL = CAP_ALL,
     };
+    
+    /**
+     * Move constructs a gravity model.
+     **********************************************************************/
+    GravityModel(GravityModel&&) = default;
+    
+    /**
+     * Move assigns a gravity model.
+     **********************************************************************/
+    GravityModel& operator=(GravityModel&&) = default;
+    
     /** \name Setting up the gravity model
      **********************************************************************/
     ///@{

--- a/include/GeographicLib/MagneticModel.hpp
+++ b/include/GeographicLib/MagneticModel.hpp
@@ -93,6 +93,16 @@ namespace GeographicLib {
     // nor copy assignment
     MagneticModel& operator=(const MagneticModel&) = delete;
   public:
+    
+    /**
+     * Move constructs a magnetic model.
+     **********************************************************************/
+    MagneticModel(MagneticModel&&) = default;
+    
+    /**
+     * Move assigns a magnetic model.
+     **********************************************************************/
+    MagneticModel& operator=(MagneticModel&&) = default;
 
     /** \name Setting up the magnetic model
      **********************************************************************/


### PR DESCRIPTION
Since the move constructor/assignment functions cannot be implicitly defined, I have added them as `default`, so that the `MagneticModel` class can be moved.