### PR TITLE
add BUILD_TESTING to conditional within tests/CMakeLists.txt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ set (TESTPROGRAMS geodtest signtest polygontest intersecttest)
 add_custom_target (testprograms)
 add_dependencies (testprograms tools)
 
-if (GEOGRAPHICLIB_PRECISION GREATER 1)
+if (BUILD_TESTING AND (GEOGRAPHICLIB_PRECISION GREATER 1))
 
   foreach (TESTPROGRAM ${TESTPROGRAMS})
 


### PR DESCRIPTION
workaround for 'colcon test' getting its knickers in a twist when geographiclib is used as a submodule