### PR TITLE
Add MSVC flag to suppress warning 4819

### DIFF
--- a/include/GeographicLib/DMS.hpp
+++ b/include/GeographicLib/DMS.hpp
@@ -384,8 +384,4 @@ namespace GeographicLib {
 
 } // namespace GeographicLib
 
-#if defined(_MSC_VER)
-#  pragma warning (pop)
-#endif
-
 #endif  // GEOGRAPHICLIB_DMS_HPP

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -51,7 +51,7 @@ namespace GeographicLib {
     // January, February as 0-9, 10, 11.
     //
     // 3. The pattern of month lengths from March through January is regular
-    // with a 5-month period—31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31. The
+    // with a 5-month period-31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31. The
     // 5-month period is 153 days long. Since February is now at the end of
     // the year, we don't need to include its length in this part of the
     // calculation.


### PR DESCRIPTION
When I put geographiclib as a submodule into my project to compile, I get the following error (in MSVC):

``` text
[{
	"resource": "/myProject/3rdparty/geographiclib/src/Utility.cpp",
	"owner": "cmake-build-diags",
	"code": "C2220",
	"severity": 8,
	"message": "以下警告被视为错误 [E:\\dataFiles\\github\\ElevationManager\\build\\3rdparty\\geographiclib\\src\\GeographicLib_SHARED.vcxproj]",
	"source": "MSVC",
	"startLineNumber": 1,
	"startColumn": 1,
	"endLineNumber": 1,
	"endColumn": 1,
	"origin": "extHost1",
	"extensionID": "ms-vscode.cmake-tools"
},{
	"resource": "/myProject/3rdparty/geographiclib/src/Utility.cpp",
	"owner": "cmake-build-diags",
	"code": "C4819",
	"severity": 4,
	"message": "该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失 [E:\\dataFiles\\github\\ElevationManager\\build\\3rdparty\\geographiclib\\src\\GeographicLib_SHARED.vcxproj]",
	"source": "MSVC",
	"startLineNumber": 1,
	"startColumn": 1,
	"endLineNumber": 1,
	"endColumn": 1,
	"origin": "extHost1",
	"extensionID": "ms-vscode.cmake-tools"
}]
```

Not only **Utility.cpp**, but also **DMS.hpp** and **DMS.cpp**. I see this setting in the DSM's documentation, but I'm not sure why it's not working, even though I'm pulling the repository master branch directly to compile, I'm experiencing the same problem.

``` cpp
#if defined(_MSC_VER)
// Squelch warnings about unrepresentable characters
#  pragma warning (disable: 4819)
#endif
```

So I added `/wd4819` to `CMAKE_CXX_FLAGS` and now he compiles and works fine on my device. I'm on windows 10 and the MSVC version info is as follows:

``` text
[cmake] -- The C compiler identification is MSVC 19.29.30157.0
[cmake] -- The CXX compiler identification is MSVC 19.29.30157.0
```

If you know why `# pragma warning (disable: 4819)` didn't take effect, please let me know. Otherwise I think an overall setting of `/wd4819` would be a good choice as well, thanks :)