### PR TITLE
Add missing initialization to Math::NaN().

### DIFF
--- a/src/Geodesic.cpp
+++ b/src/Geodesic.cpp
@@ -215,7 +215,7 @@ namespace GeographicLib {
     // check, e.g., on verifying quadrants in atan2.  In addition, this
     // enforces some symmetries in the results returned.
 
-    real sbet1, cbet1, sbet2, cbet2, s12x, m12x = Math::NaN();
+    real sbet1 = Math::NaN(), cbet1 = Math::NaN(), sbet2 = Math::NaN(), cbet2 = Math::NaN(), s12x = Math::NaN(), m12x = Math::NaN();
 
     Math::sincosd(lat1, sbet1, cbet1); sbet1 *= _f1;
     // Ensure cbet1 = +epsilon at poles; doing the fix on beta means that sig12

--- a/src/GeodesicExact.cpp
+++ b/src/GeodesicExact.cpp
@@ -488,7 +488,7 @@ namespace GeographicLib {
     // check, e.g., on verifying quadrants in atan2.  In addition, this
     // enforces some symmetries in the results returned.
 
-    real sbet1, cbet1, sbet2, cbet2, s12x, m12x = Math::NaN();
+    real sbet1 = Math::NaN(), cbet1 = Math::NaN(), sbet2 = Math::NaN(), cbet2 = Math::NaN(), s12x = Math::NaN(), m12x = Math::NaN();
     // Initialize for the meridian.  No longitude calculation is done in this
     // case to let the parameter default to 0.
     EllipticFunction E(-_ep2);


### PR DESCRIPTION
Avoids uninitialized variable errors (-Werror) with GCC in some configurations.

(I got the error for `s12x`, it's also shown as warning with clangd in the QtCreator GUI in my configuration...)